### PR TITLE
option to build and run the recipe directly from dataset object

### DIFF
--- a/Samples/london-no2.py
+++ b/Samples/london-no2.py
@@ -15,6 +15,4 @@ attribute_matcher = AttributeMatcher(provider='erg.kcl.ac.uk', label='NO2 40 ug/
 lvf = LatestValueField(attribute_matcher=attribute_matcher, label='Anual NO2')
 
 dataset = Dataset(subjects=[subjects], datasources=[datasources], fields=[lvf])
-recipe = Recipe(dataset=dataset)
-recipe.build_recipe(output_location=recipe_output_location)
-recipe.run_recipe(tombolo_path=tombolo_path, output_path=model_output)
+dataset.build_and_run(tombolo_path=tombolo_path, model_output_location=model_output, console_print=True)

--- a/Samples/london-no2.py
+++ b/Samples/london-no2.py
@@ -15,4 +15,5 @@ attribute_matcher = AttributeMatcher(provider='erg.kcl.ac.uk', label='NO2 40 ug/
 lvf = LatestValueField(attribute_matcher=attribute_matcher, label='Anual NO2')
 
 dataset = Dataset(subjects=[subjects], datasources=[datasources], fields=[lvf])
-dataset.build_and_run(tombolo_path=tombolo_path, model_output_location=model_output, console_print=True)
+dataset.build_and_run(tombolo_path=tombolo_path, model_output_location=model_output, 
+                        recipe_console_print=True)

--- a/recipe.py
+++ b/recipe.py
@@ -108,6 +108,37 @@ class Dataset(object):
         self.datasources = datasources
         self.fields = fields
 
+    def build_recipe(self, recipe_output_location=None, console_print=False):
+        """Builds the recipe from the class object
+
+        Args: 
+            `recipe_output_location`: (Optional) If you would like to save the recipe file, pass the location.    
+            `console_print`: (Optional) To print the recipe on console.    
+        """
+
+        recipe = Recipe(self)
+        recipe.build_recipe(output_location=recipe_output_location, console_print=console_print)
+
+    def build_and_run(self, tombolo_path, model_output_location, force_imports=None, 
+                      clear_database_cache=False, gradle_path=None, recipe_output_location=None, 
+                      console_print=False):
+        """Runs the recipe directly from Python console
+
+        Args: 
+            `tombolo_path`: Path of the tombolo project.  
+            `model_output_location`: Path of the file where you want the output to be saved.  
+            `force_imports`: (Optional) If you would like to import the datasource for the importer again.    
+            `clear_database_cache`: (Optional) To clear the database.    
+            `gradle_path`: (Optional) If gradle path is not set in env variables, use this option to pass gradle path.
+            `recipe_output_location`: (Optional) If you would like to save the recipe file, pass the location.
+            `console_print`: (Optional) To print the output logs on Terminal
+        """
+        
+        recipe = Recipe(self)
+        recipe.build_recipe(output_location=recipe_output_location, console_print=console_print)
+        recipe.run_recipe(tombolo_path=tombolo_path, output_path=model_output_location, force_imports=force_imports,
+                          clear_database_cache=clear_database_cache, gradle_path=gradle_path)
+
 class AttributeMatcher(object):
     """Creates a AttributeMatcher Object
 

--- a/recipe.py
+++ b/recipe.py
@@ -120,8 +120,8 @@ class Dataset(object):
         recipe.build_recipe(output_location=recipe_output_location, console_print=console_print)
 
     def build_and_run(self, tombolo_path, model_output_location, force_imports=None, 
-                      clear_database_cache=False, gradle_path=None, recipe_output_location=None, 
-                      console_print=False):
+                      clear_database_cache=False, gradle_path=None, model_output_console_print=True,
+                      recipe_output_location=None, recipe_console_print=False):
         """Runs the recipe directly from Python console
 
         Args: 
@@ -131,13 +131,15 @@ class Dataset(object):
             `clear_database_cache`: (Optional) To clear the database.    
             `gradle_path`: (Optional) If gradle path is not set in env variables, use this option to pass gradle path.
             `recipe_output_location`: (Optional) If you would like to save the recipe file, pass the location.
-            `console_print`: (Optional) To print the output logs on Terminal
+            `recipe_console_print`: (Optional) To print the output logs on Terminal
+            `model_output_console_print`: (Optional) To print the output logs on Terminal
         """
-        
+
         recipe = Recipe(self)
-        recipe.build_recipe(output_location=recipe_output_location, console_print=console_print)
+        recipe.build_recipe(output_location=recipe_output_location, console_print=recipe_console_print)
         recipe.run_recipe(tombolo_path=tombolo_path, output_path=model_output_location, force_imports=force_imports,
-                          clear_database_cache=clear_database_cache, gradle_path=gradle_path)
+                          clear_database_cache=clear_database_cache, gradle_path=gradle_path, 
+                          console_print=model_output_console_print)
 
 class AttributeMatcher(object):
     """Creates a AttributeMatcher Object


### PR DESCRIPTION
Added option to build and run the recipe directly from the dataset object and in one command,
the code is still backward compatible.
Please refer to the london-no2.py in Samples folder for the new updated syntax