### PR TITLE
use of print option to print the recipe

### DIFF
--- a/recipe.py
+++ b/recipe.py
@@ -107,9 +107,6 @@ class Dataset(object):
         self.subjects = subjects
         self.datasources = datasources
         self.fields = fields
-        
-    def __repr__(self):
-        return print_(self)
 
     def __str__(self):
         return print_(self)
@@ -165,9 +162,6 @@ class AttributeMatcher(object):
         if values:
             self.values = values
 
-    def __repr__(self):
-        return print_(self)
-
     def __str__(self):
         return print_(self)
 
@@ -194,9 +188,6 @@ class Datasource(object):
         if local_data:
             self.localData = local_data
 
-    def __repr__(self):
-        return print_(self)
-
     def __str__(self):
         return print_(self)
 
@@ -221,9 +212,6 @@ class Subject(object):
             is_of_type(Geo_Match_Rule, geo_match_rule, 'geo_match_rule must be of type Geo_Match_Rule')
             self.geoMatchRule = geo_match_rule
 
-    def __repr__(self):
-        return print_(self)
-
     def __str__(self):
         return print_(self)
 
@@ -241,9 +229,6 @@ class Geo_Match_Rule(object):
         all_same_type(Subject, subjects, 'subjects should be a list of subjects')
         self.subjects = subjects
 
-    def __repr__(self):
-        return print_(self)
-
     def __str__(self):
         return print_(self)
 
@@ -258,9 +243,6 @@ class Match_Rule(object):
     def __init__(self, attribute_to_match_on, pattern):
         self.attribute = attribute_to_match_on
         self.pattern = pattern
-
-    def __repr__(self):
-        return print_(self)
 
     def __str__(self):
         return print_(self)
@@ -297,9 +279,6 @@ class AreaField(Field):
         super().__init__(field_class=package_name_transformation + 'AreaField', label=label)
         self.targetCRSCode = target_crs_code
 
-    def __repr__(self):
-        return print_(self)
-
     def __str__(self):
         return print_(self)
 
@@ -323,9 +302,6 @@ class ArithmeticField(Field):
         self.field1 = operation_on_field_1
         self.field2 = operation_on_field_2
 
-    def __repr__(self):
-        return print_(self)
-
     def __str__(self):
         return print_(self)
 
@@ -345,9 +321,6 @@ class DescriptiveStatisticsField(Field):
         super().__init__(field_class=package_name_transformation + 'DescriptiveStatisticsField', label=label)
         self.statistic = statistic
         self.fields = fields
-
-    def __repr__(self):
-        return print_(self)
 
     def __str__(self):
         return print_(self)
@@ -369,9 +342,6 @@ class FieldValueSumField(Field):
         self.name = name
         self.fields = fields
 
-    def __repr__(self):
-        return print_(self)
-
     def __str__(self):
         return print_(self)
 
@@ -392,9 +362,6 @@ class FractionOfTotalField(Field):
         super().__init__(field_class=package_name_transformation + 'FractionOfTotalField', label=label)
         self.dividendAttributes = dividend_attributes
         self.divisorAttribute = divisor_attribute
-
-    def __repr__(self):
-        return print_(self)
 
     def __str__(self):
         return print_(self)
@@ -419,9 +386,6 @@ class LinearCombinationField(Field):
         self.scalars = scalars
         self.fields = fields
 
-    def __repr__(self):
-        return print_(self)
-
     def __str__(self):
         return print_(self)
 
@@ -441,9 +405,6 @@ class ListArithmeticField(Field):
         super().__init__(field_class=package_name_transformation + 'ListArithmeticField', label=label)
         self.operation = operation
         self.fields = fields
-
-    def __repr__(self):
-        return print_(self)
 
     def __str__(self):
         return print_(self)
@@ -474,9 +435,6 @@ class PercentilesField(Field):
             all_same_type(Subject, normalization_subjects, 'subjects should be of type Subject')
             self.subjects = normalization_subjects
 
-    def __repr__(self):
-        return print_(self)
-
     def __str__(self):
         return print_(self)
 
@@ -500,9 +458,6 @@ class BasicValueField(Field):
             is_of_type(AttributeMatcher, attribute_matcher, 'attribute_matcher should be of type AttributeMatcher')
             self.attribute = attribute_matcher
 
-    def __repr__(self):
-        return print_(self)
-
     def __str__(self):
         return print_(self)
 
@@ -517,9 +472,6 @@ class ConstantField(Field):
     def __init__(self, value, label=None):
         super().__init__(field_class=package_name_value + 'ConstantField', label=label)
         self.value = value
-
-    def __repr__(self):
-        return print_(self)
 
     def __str__(self):
         return print_(self)
@@ -536,9 +488,6 @@ class FixedValueField(BasicValueField):
         super().__init__(attribute_matcher=attribute_matcher, field_class=package_name_value + 'FixedValueField', 
                         label=label)
 
-    def __repr__(self):
-        return print_(self)
-
     def __str__(self):
         return print_(self)
 
@@ -554,9 +503,6 @@ class LatestValueField(BasicValueField):
         super().__init__(attribute_matcher=attribute_matcher, field_class=package_name_value + 'LatestValueField', 
                         label=label)
 
-    def __repr__(self):
-        return print_(self)
-
     def __str__(self):
         return print_(self)
 
@@ -569,9 +515,6 @@ class SubjectLatitudeField(Field):
 
     def __init__(self, label=None):
         super().__init__(field_class=package_name_value + 'SubjectLatitudeField', label=label)
-
-    def __repr__(self):
-        return print_(self)
 
     def __str__(self):
         return print_(self)
@@ -586,9 +529,6 @@ class SubjectLongitudeField(Field):
     def __init__(self, label=None):
         super().__init__(field_class=package_name_value + 'SubjectLongitudeField', label=label)
 
-    def __repr__(self):
-        return print_(self)
-
     def __str__(self):
         return print_(self)
 
@@ -601,9 +541,6 @@ class SubjectNameField(Field):
 
     def __init__(self, label=None):
         super().__init__(field_class=package_name_value + 'SubjectNameField', label=label)
-
-    def __repr__(self):
-        return print_(self)
 
     def __str__(self):
         return print_(self)
@@ -620,9 +557,6 @@ class TimeseriesField(BasicValueField):
         super().__init__(field_class=package_name_value + 'TimeseriesField', label=label, 
                         attribute_matcher=attribute_matcher)
 
-    def __repr__(self):
-        return print_(self)
-
     def __str__(self):
         return print_(self)
 
@@ -637,9 +571,6 @@ class TimeseriesMeanValueField(BasicValueField):
     def __init__(self, label=None, attribute_matcher=None):
         super().__init__(field_class=package_name_value + 'TimeseriesMeanValueField', label=label, 
                         attribute_matcher=attribute_matcher)
-
-    def __repr__(self):
-        return print_(self)
 
     def __str__(self):
         return print_(self)
@@ -664,9 +595,6 @@ class BackOffField(Field):
         super().__init__(field_class=package_name_aggregation + 'BackOffField', label=label)
         self.fields = fields
 
-    def __repr__(self):
-        return print_(self)
-
     def __str__(self):
         return print_(self)
 
@@ -689,9 +617,6 @@ class GeographicAggregationField(Field):
         self.function = function
         self.field = field
 
-    def __repr__(self):
-        return print_(self)
-
     def __str__(self):
         return print_(self)
 
@@ -711,9 +636,6 @@ class MapToContainingSubjectField(Field):
         super().__init__(field_class=package_name_aggregation + 'MapToContainingSubjectField', label=label)
         self.subject = subject
         self.field = field
-
-    def __repr__(self):
-        return print_(self)
 
     def __str__(self):
         return print_(self)
@@ -737,9 +659,6 @@ class MapToNearestSubjectField(Field):
         self.maxRadius = max_radius
         self.subject = subject
         self.field = field
-
-    def __repr__(self):
-        return print_(self)
 
     def __str__(self):
         return print_(self)
@@ -770,9 +689,6 @@ class AttributeMatcherField(Field):
             is_of_type(Field, field, 'field should be of type Field')
             self.field = field
 
-    def __repr__(self):
-        return print_(self)
-
     def __str__(self):
         return print_(self)
 
@@ -788,9 +704,6 @@ class OSMBuiltInAttributeMatcherField(AttributeMatcherField):
     def __init__(self, attributes=None, field=None, label=None):
         super().__init__(attributes=attributes, field=field, label=label, 
                         field_class='OSMBuiltInAttributeMatcherField')
-
-    def __repr__(self):
-        return print_(self)
 
     def __str__(self):
         return print_(self)
@@ -817,9 +730,6 @@ class BasicModellingField(Field):
             all_same_type(Datasource, datasources, 'datasources should be of type Datasource')
             self.datasources = datasources
 
-    def __repr__(self):
-        return print_(self)
-
     def __str__(self):
         return print_(self)
 
@@ -835,9 +745,6 @@ class SingleValueModellingField(BasicModellingField):
     def __init__(self, recipe, datasources=None, label=None):
         super().__init__(recipe=recipe, datasources=datasources, label=label, 
                         field_class='SingleValueModellingField')
-
-    def __repr__(self):
-        return print_(self)
 
     def __str__(self):
         return print_(self)


### PR DESCRIPTION
Currently when user types the object name it print the json structure of it. Modified this so that now user would have to pass the object name in print in order to see the json.